### PR TITLE
refactor: change redirect from server to return status and url

### DIFF
--- a/src/controllers/users.ts
+++ b/src/controllers/users.ts
@@ -41,7 +41,7 @@ export const signIn = async (req, res) => {
         const url = new URL(process.env.HUB_URL);
         url.searchParams.set('auth_token', token);
         res.status(200);
-        return res.redirect(url);
+        return res.json({ data: url });
     }
 
     res.status(400);


### PR DESCRIPTION
Initially `res.redirect()` was being used to redirect the client to another site instead of just returning the redirect URL and status code.  As a result the following CORS error was thrown:

`Access to XMLHttpRequest at 'REDIRECT-URL' (redirected from 'https://auth.techjedi.dev/signin') from origin 'https://eloquent-gecko-f34d44.netlify.app' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource.`

To resolve, instead of a redirect from the server the URL is being sent back to the client and redirect will be handled on frontend.